### PR TITLE
[DOC] Setting is config.xmpp.server, not config.xmpp.host

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In your Adhearsion app configuration file, add the following values:
 Adhearsion.config do |config|
   config.xmpp.jid      = "valid-jid"
   config.xmpp.password = "valid-password"
-  config.xmpp.host     = "valid-host"
+  config.xmpp.server   = "valid-server"
   config.xmpp.port     = "valid-port"
 end
 ```


### PR DESCRIPTION
This tripped me up just now. It should probably be consistent with config.punchblock.host but changing the documentation is safer. :-)
