### PR TITLE
[BUGFIX] Fix require of blather/client stuff, blather/client.rb is an executable script now?

### DIFF
--- a/lib/adhearsion/xmpp/connection.rb
+++ b/lib/adhearsion/xmpp/connection.rb
@@ -1,4 +1,5 @@
-require 'blather/client'
+require 'blather/client/client'
+require 'blather/client/dsl'
 
 module Adhearsion
   class XMPP


### PR DESCRIPTION
(resubmit of #7 on different branch)

asterisk-xmpp without Punchblock is broken because of issues #6 but even after defining run_blather myself, I still faced another problem. Assuming this isn't a problem with Blather, this patch should do the trick.

```
Starting Adhearsion server at /home/jlecuirot/imgui/AgentPay/ahn
[2012-06-04 10:43:42] INFO  Adhearsion::Initializer: Setting RAILS_ENV to "development"
[2012-06-04 10:43:42] DEBUG Punchblock::Translator::Asterisk: Starting up...
Run with ahn [options] user@server/resource password [host] [port]
    -D, --debug                      Run in debug mode (you will see all XMPP communication)
    -d, --daemonize                  Daemonize the process
        --pid=[PID]                  Write the PID to this file
        --log=[LOG]                  Write to the [LOG] file instead of stdout/stderr
        --certs=[CERTS DIRECTORY]    The directory path where the trusted certificates are stored
    -h, --help                       Show this message
    -v, --version                    Show version
[2012-06-04 10:43:43] INFO  Celluloid: Terminating 1 actors...
[2012-06-04 10:43:43] INFO  Celluloid: Shutdown completed cleanly
/home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/blather-0.7.1/lib/blather/client/client.rb:218:in `stream': Stream not ready! (RuntimeError)
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/blather-0.7.1/lib/blather/client/client.rb:171:in `close'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/blather-0.7.1/lib/blather/client/dsl.rb:134:in `shutdown'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/adhearsion-2.0.0/lib/adhearsion/punchblock_plugin/initializer.rb:95:in `connect'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/adhearsion-2.0.0/lib/adhearsion/punchblock_plugin/initializer.rb:82:in `run'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/adhearsion-2.0.0/lib/adhearsion/punchblock_plugin.rb:33:in `block in <class:PunchblockPlugin>'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/adhearsion-2.0.0/lib/adhearsion/plugin/initializer.rb:26:in `instance_exec'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/adhearsion-2.0.0/lib/adhearsion/plugin/initializer.rb:26:in `run'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/adhearsion-2.0.0/lib/adhearsion/plugin.rb:172:in `block in run_plugins'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/adhearsion-2.0.0/lib/adhearsion/plugin.rb:171:in `each'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/adhearsion-2.0.0/lib/adhearsion/plugin.rb:171:in `run_plugins'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/adhearsion-2.0.0/lib/adhearsion/initializer.rb:207:in `run_plugins'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/adhearsion-2.0.0/lib/adhearsion/initializer.rb:56:in `start'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/adhearsion-2.0.0/lib/adhearsion/initializer.rb:12:in `start'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/adhearsion-2.0.0/lib/adhearsion/cli_commands.rb:120:in `start_app'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/adhearsion-2.0.0/lib/adhearsion/cli_commands.rb:59:in `start'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.15.2/lib/thor/task.rb:27:in `run'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.15.2/lib/thor/invocation.rb:120:in `invoke_task'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.15.2/lib/thor.rb:275:in `dispatch'
    from /home/jlecuirot/.rvm/gems/ruby-1.9.3-p194/gems/thor-0.15.2/lib/thor/base.rb:408:in `start'
    from script/ahn:9:in `<main>'
```
